### PR TITLE
Fix static files

### DIFF
--- a/semantic/settings.py
+++ b/semantic/settings.py
@@ -108,7 +108,7 @@ USE_THOUSAND_SEPARATOR = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
-STATICFILES_DIRS = (os.path.join(BASE_DIR, 'semantic', 'staticfiles'),)
-STATIC_ROOT = os.path.join(BASE_DIR, 'semantic', 'static')
+STATICFILES_DIRS = (os.path.join(BASE_DIR, 'semantic', 'static'),)
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 LOGIN_URL = '/admin/login/'


### PR DESCRIPTION
1. Run `python manage.py collectstatic`
2. Server logs shows `HTTP 200` for all static files

```
$ python manage.py runserver
Performing system checks...

System check identified no issues (0 silenced).
September 15, 2016 - 16:22:40
Django version 1.10.1, using settings 'semantic.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
[15/Sep/2016 16:22:43] "GET / HTTP/1.1" 200 2442
[15/Sep/2016 16:22:43] "GET /static/css/reset.css HTTP/1.1" 200 8441
[15/Sep/2016 16:22:43] "GET /static/css/site.css HTTP/1.1" 200 2652
[15/Sep/2016 16:22:43] "GET /static/css/container.css HTTP/1.1" 200 2977
[15/Sep/2016 16:22:43] "GET /static/css/grid.css HTTP/1.1" 200 70098
[15/Sep/2016 16:22:43] "GET /static/css/header.css HTTP/1.1" 200 12331
[15/Sep/2016 16:22:43] "GET /static/css/image.css HTTP/1.1" 200 5279
[15/Sep/2016 16:22:43] "GET /static/css/menu.css HTTP/1.1" 200 42015
[15/Sep/2016 16:22:43] "GET /static/css/dropdown.css HTTP/1.1" 200 33914
[15/Sep/2016 16:22:43] "GET /static/css/divider.css HTTP/1.1" 200 7842
[15/Sep/2016 16:22:43] "GET /static/css/segment.css HTTP/1.1" 200 16316
[15/Sep/2016 16:22:43] "GET /static/css/list.css HTTP/1.1" 200 21452
[15/Sep/2016 16:22:43] "GET /static/css/button.css HTTP/1.1" 200 90632
[15/Sep/2016 16:22:43] "GET /static/css/icon.css HTTP/1.1" 200 52491
[15/Sep/2016 16:22:43] "GET /static/css/sidebar.css HTTP/1.1" 200 15445
[15/Sep/2016 16:22:43] "GET /static/css/index.css HTTP/1.1" 200 1378
[15/Sep/2016 16:22:43] "GET /static/js/sidebar.js HTTP/1.1" 200 33473
[15/Sep/2016 16:22:43] "GET /static/css/transition.css HTTP/1.1" 200 46094
[15/Sep/2016 16:22:43] "GET /static/js/visibility.js HTTP/1.1" 200 41641
[15/Sep/2016 16:22:43] "GET /static/js/jquery.min.js HTTP/1.1" 200 84345
[15/Sep/2016 16:22:43] "GET /static/js/transition.js HTTP/1.1" 200 34756
[15/Sep/2016 16:22:43] "GET /static/js/index.js HTTP/1.1" 200 468
```
